### PR TITLE
Make failure to recalculate device parameters warn instead of error

### DIFF
--- a/src/dpdb.js
+++ b/src/dpdb.js
@@ -80,7 +80,7 @@ Dpdb.prototype.recalculateDeviceParams_ = function() {
       this.onDeviceParamsUpdated(this.deviceParams);
     }
   } else {
-    console.error('Failed to recalculate device parameters.');
+    console.warn('Failed to recalculate device parameters.');
   }
 };
 


### PR DESCRIPTION
... since this can also happen when there is no "hard error" at all, e.g. when your device is not in the list DPDB list (e.g. when it's a desktop machine without any VR device attached).

This should be a warning, because

```
console.warn('No DPDB device match.');
return null;
```

is a warning too, but since `null` is returned, it becomes an error as `console.error('Failed to recalculate device parameters.');` straight after.

Real errors are already logged with `console.error` in `calcDeviceParams_`, e.g. `console.error('DPDB has unexpected format version.');`.
